### PR TITLE
refactor(web): 웹훅 포맷터 Strategy 패턴 적용

### DIFF
--- a/apps/web/src/lib/webhook/formatters/discord.ts
+++ b/apps/web/src/lib/webhook/formatters/discord.ts
@@ -1,0 +1,33 @@
+import type { WebhookFormatter, WebhookContext } from "../types";
+import { getTypeInfo, getEventLabel } from "../utils";
+
+const TYPE_COLORS: Record<string, number> = {
+  BUG: 0xef4444,
+  FEATURE: 0x8b5cf6,
+  INQUIRY: 0x3b82f6,
+};
+
+export const discordFormatter: WebhookFormatter = {
+  format(context: WebhookContext) {
+    const { feedback, project, isTest } = context;
+    const typeInfo = getTypeInfo(feedback.type);
+    const eventLabel = getEventLabel(isTest);
+
+    return {
+      embeds: [
+        {
+          title: eventLabel,
+          color: TYPE_COLORS[feedback.type] ?? 0x3b82f6,
+          fields: [
+            { name: "유형", value: `${typeInfo.emoji} ${typeInfo.label}`, inline: true },
+            { name: "프로젝트", value: project.name, inline: true },
+            { name: "메시지", value: feedback.message },
+            ...(feedback.email ? [{ name: "이메일", value: feedback.email, inline: true }] : []),
+            ...(feedback.metadata?.url ? [{ name: "URL", value: feedback.metadata.url }] : []),
+          ],
+          timestamp: new Date().toISOString(),
+        },
+      ],
+    };
+  },
+};

--- a/apps/web/src/lib/webhook/formatters/generic.ts
+++ b/apps/web/src/lib/webhook/formatters/generic.ts
@@ -1,0 +1,15 @@
+import type { WebhookFormatter, WebhookContext } from "../types";
+
+export const genericFormatter: WebhookFormatter = {
+  format(context: WebhookContext) {
+    const { feedback, project, organization, isTest } = context;
+
+    return {
+      event: isTest ? "webhook.test" : "feedback.created",
+      timestamp: new Date().toISOString(),
+      feedback,
+      project,
+      organization,
+    };
+  },
+};

--- a/apps/web/src/lib/webhook/formatters/index.ts
+++ b/apps/web/src/lib/webhook/formatters/index.ts
@@ -1,0 +1,23 @@
+import type { WebhookFormatter } from "../types";
+import { slackFormatter } from "./slack";
+import { discordFormatter } from "./discord";
+import { telegramFormatter } from "./telegram";
+import { genericFormatter } from "./generic";
+
+interface FormatterConfig {
+  pattern: string;
+  formatter: WebhookFormatter;
+}
+
+const formatters: FormatterConfig[] = [
+  { pattern: "hooks.slack.com", formatter: slackFormatter },
+  { pattern: "discord.com/api/webhooks", formatter: discordFormatter },
+  { pattern: "api.telegram.org", formatter: telegramFormatter },
+];
+
+export function getFormatter(webhookUrl: string): WebhookFormatter {
+  const matched = formatters.find((config) => webhookUrl.includes(config.pattern));
+  return matched?.formatter ?? genericFormatter;
+}
+
+export { slackFormatter, discordFormatter, telegramFormatter, genericFormatter };

--- a/apps/web/src/lib/webhook/formatters/slack.ts
+++ b/apps/web/src/lib/webhook/formatters/slack.ts
@@ -1,0 +1,36 @@
+import type { WebhookFormatter, WebhookContext } from "../types";
+import { getTypeInfo, getEventLabel } from "../utils";
+
+export const slackFormatter: WebhookFormatter = {
+  format(context: WebhookContext) {
+    const { feedback, project, isTest } = context;
+    const typeInfo = getTypeInfo(feedback.type);
+    const eventLabel = getEventLabel(isTest);
+
+    return {
+      blocks: [
+        {
+          type: "header",
+          text: { type: "plain_text", text: eventLabel, emoji: true },
+        },
+        {
+          type: "section",
+          fields: [
+            { type: "mrkdwn", text: `*유형:*\n${typeInfo.emoji} ${typeInfo.label}` },
+            { type: "mrkdwn", text: `*프로젝트:*\n${project.name}` },
+          ],
+        },
+        {
+          type: "section",
+          text: { type: "mrkdwn", text: `*메시지:*\n${feedback.message}` },
+        },
+        ...(feedback.email
+          ? [{ type: "section", fields: [{ type: "mrkdwn", text: `*이메일:*\n${feedback.email}` }] }]
+          : []),
+        ...(feedback.metadata?.url
+          ? [{ type: "context", elements: [{ type: "mrkdwn", text: `📍 ${feedback.metadata.url}` }] }]
+          : []),
+      ],
+    };
+  },
+};

--- a/apps/web/src/lib/webhook/formatters/telegram.ts
+++ b/apps/web/src/lib/webhook/formatters/telegram.ts
@@ -1,0 +1,33 @@
+import type { WebhookFormatter, WebhookContext } from "../types";
+import { getTypeInfo, getEventLabel } from "../utils";
+
+export const telegramFormatter: WebhookFormatter = {
+  format(context: WebhookContext) {
+    const { feedback, project, isTest } = context;
+    const typeInfo = getTypeInfo(feedback.type);
+    const eventLabel = getEventLabel(isTest);
+
+    const lines = [
+      `<b>${eventLabel}</b>`,
+      ``,
+      `${typeInfo.emoji} <b>유형:</b> ${typeInfo.label}`,
+      `📁 <b>프로젝트:</b> ${project.name}`,
+      ``,
+      `💬 <b>메시지:</b>`,
+      feedback.message,
+    ];
+
+    if (feedback.email) {
+      lines.push(``, `📧 <b>이메일:</b> ${feedback.email}`);
+    }
+
+    if (feedback.metadata?.url) {
+      lines.push(``, `🔗 ${feedback.metadata.url}`);
+    }
+
+    return {
+      text: lines.join("\n"),
+      parse_mode: "HTML",
+    };
+  },
+};

--- a/apps/web/src/lib/webhook/index.ts
+++ b/apps/web/src/lib/webhook/index.ts
@@ -1,0 +1,17 @@
+export * from "./types";
+export * from "./utils";
+export { getFormatter } from "./formatters";
+
+import type { FeedbackData, ProjectData, OrganizationData } from "./types";
+import { getFormatter } from "./formatters";
+
+export function formatWebhookPayload(
+  webhookUrl: string,
+  feedback: FeedbackData,
+  project: ProjectData,
+  organization: OrganizationData,
+  isTest = false
+): unknown {
+  const formatter = getFormatter(webhookUrl);
+  return formatter.format({ feedback, project, organization, isTest });
+}

--- a/apps/web/src/lib/webhook/types.ts
+++ b/apps/web/src/lib/webhook/types.ts
@@ -1,0 +1,33 @@
+export interface FeedbackData {
+  id: string;
+  type: string;
+  message: string;
+  email: string | null;
+  metadata: { url?: string } | null;
+}
+
+export interface ProjectData {
+  id: string;
+  name: string;
+}
+
+export interface OrganizationData {
+  id: string;
+  name: string;
+}
+
+export interface WebhookContext {
+  feedback: FeedbackData;
+  project: ProjectData;
+  organization: OrganizationData;
+  isTest: boolean;
+}
+
+export interface WebhookFormatter {
+  format(context: WebhookContext): unknown;
+}
+
+export interface TypeInfo {
+  emoji: string;
+  label: string;
+}

--- a/apps/web/src/lib/webhook/utils.ts
+++ b/apps/web/src/lib/webhook/utils.ts
@@ -1,0 +1,18 @@
+import type { TypeInfo } from "./types";
+
+export function getTypeInfo(type: string): TypeInfo {
+  switch (type) {
+    case "BUG":
+      return { emoji: "🐛", label: "버그 리포트" };
+    case "FEATURE":
+      return { emoji: "💡", label: "기능 요청" };
+    case "INQUIRY":
+      return { emoji: "❓", label: "문의" };
+    default:
+      return { emoji: "📝", label: type };
+  }
+}
+
+export function getEventLabel(isTest: boolean): string {
+  return isTest ? "🔔 웹훅 테스트" : "🔔 새 피드백";
+}

--- a/apps/web/src/server/organization.ts
+++ b/apps/web/src/server/organization.ts
@@ -9,6 +9,7 @@ import {
   getOrganizationBySlug,
 } from "@sori/database";
 import { getSessionUserId, requireOrgMembership, requireOrgAdmin } from "./auth-helpers";
+import { formatWebhookPayload } from "@/lib/webhook";
 
 // ============================================
 // 조직 생성 (인증 필요)
@@ -96,110 +97,6 @@ export const updateOrganizationWebhook = createServerFn({ method: "POST" })
 
     return await updateOrganizationWebhookQuery(organizationId, webhookUrl);
   });
-
-// Get type emoji and label for webhook formatting
-function getTypeInfo(type: string) {
-  switch (type) {
-    case "BUG": return { emoji: "🐛", label: "버그 리포트" };
-    case "FEATURE": return { emoji: "💡", label: "기능 요청" };
-    case "INQUIRY": return { emoji: "❓", label: "문의" };
-    default: return { emoji: "📝", label: type };
-  }
-}
-
-// Format payload for different webhook services
-function formatWebhookPayload(
-  webhookUrl: string,
-  feedback: { id: string; type: string; message: string; email: string | null; metadata: { url?: string } | null },
-  project: { id: string; name: string },
-  organization: { id: string; name: string },
-  isTest = false
-) {
-  const typeInfo = getTypeInfo(feedback.type);
-  const eventLabel = isTest ? "🔔 웹훅 테스트" : "🔔 새 피드백";
-
-  // Slack format
-  if (webhookUrl.includes("hooks.slack.com")) {
-    return {
-      blocks: [
-        {
-          type: "header",
-          text: { type: "plain_text", text: eventLabel, emoji: true },
-        },
-        {
-          type: "section",
-          fields: [
-            { type: "mrkdwn", text: `*유형:*\n${typeInfo.emoji} ${typeInfo.label}` },
-            { type: "mrkdwn", text: `*프로젝트:*\n${project.name}` },
-          ],
-        },
-        {
-          type: "section",
-          text: { type: "mrkdwn", text: `*메시지:*\n${feedback.message}` },
-        },
-        ...(feedback.email
-          ? [{ type: "section", fields: [{ type: "mrkdwn", text: `*이메일:*\n${feedback.email}` }] }]
-          : []),
-        ...(feedback.metadata?.url
-          ? [{ type: "context", elements: [{ type: "mrkdwn", text: `📍 ${feedback.metadata.url}` }] }]
-          : []),
-      ],
-    };
-  }
-
-  // Discord format
-  if (webhookUrl.includes("discord.com/api/webhooks")) {
-    return {
-      embeds: [
-        {
-          title: eventLabel,
-          color: feedback.type === "BUG" ? 0xef4444 : feedback.type === "FEATURE" ? 0x8b5cf6 : 0x3b82f6,
-          fields: [
-            { name: "유형", value: `${typeInfo.emoji} ${typeInfo.label}`, inline: true },
-            { name: "프로젝트", value: project.name, inline: true },
-            { name: "메시지", value: feedback.message },
-            ...(feedback.email ? [{ name: "이메일", value: feedback.email, inline: true }] : []),
-            ...(feedback.metadata?.url ? [{ name: "URL", value: feedback.metadata.url }] : []),
-          ],
-          timestamp: new Date().toISOString(),
-        },
-      ],
-    };
-  }
-
-  // Telegram format (Bot API)
-  if (webhookUrl.includes("api.telegram.org")) {
-    const lines = [
-      `<b>${eventLabel}</b>`,
-      ``,
-      `${typeInfo.emoji} <b>유형:</b> ${typeInfo.label}`,
-      `📁 <b>프로젝트:</b> ${project.name}`,
-      ``,
-      `💬 <b>메시지:</b>`,
-      feedback.message,
-    ];
-    if (feedback.email) {
-      lines.push(``, `📧 <b>이메일:</b> ${feedback.email}`);
-    }
-    if (feedback.metadata?.url) {
-      lines.push(``, `🔗 ${feedback.metadata.url}`);
-    }
-
-    return {
-      text: lines.join("\n"),
-      parse_mode: "HTML",
-    };
-  }
-
-  // Generic JSON format
-  return {
-    event: isTest ? "webhook.test" : "feedback.created",
-    timestamp: new Date().toISOString(),
-    feedback,
-    project,
-    organization,
-  };
-}
 
 // Test webhook (server-side to avoid CORS)
 export const testWebhook = createServerFn({ method: "POST" })

--- a/apps/web/src/server/webhook.ts
+++ b/apps/web/src/server/webhook.ts
@@ -9,6 +9,7 @@ import {
   type Plan,
 } from "@sori/database";
 import { getOrganizationWithProjects } from "./organization";
+import { formatWebhookPayload } from "@/lib/webhook";
 
 // Plan limits for webhooks
 const WEBHOOK_LIMITS: Record<Plan, number> = {
@@ -80,77 +81,6 @@ export const deleteWebhook = createServerFn({ method: "POST" })
     await deleteWebhookQuery(data.id);
     return { success: true };
   });
-
-// Test a webhook (same format logic as organization.ts)
-function getTypeInfo(type: string) {
-  switch (type) {
-    case "BUG": return { emoji: "🐛", label: "버그 리포트" };
-    case "FEATURE": return { emoji: "💡", label: "기능 요청" };
-    case "INQUIRY": return { emoji: "❓", label: "문의" };
-    default: return { emoji: "📝", label: type };
-  }
-}
-
-function formatWebhookPayload(
-  webhookUrl: string,
-  feedback: { id: string; type: string; message: string; email: string | null; metadata: { url?: string } | null },
-  project: { id: string; name: string },
-  organization: { id: string; name: string },
-  isTest = false
-) {
-  const typeInfo = getTypeInfo(feedback.type);
-  const eventLabel = isTest ? "🔔 웹훅 테스트" : "🔔 새 피드백";
-
-  if (webhookUrl.includes("hooks.slack.com")) {
-    return {
-      blocks: [
-        { type: "header", text: { type: "plain_text", text: eventLabel, emoji: true } },
-        { type: "section", fields: [
-          { type: "mrkdwn", text: `*유형:*\n${typeInfo.emoji} ${typeInfo.label}` },
-          { type: "mrkdwn", text: `*프로젝트:*\n${project.name}` },
-        ]},
-        { type: "section", text: { type: "mrkdwn", text: `*메시지:*\n${feedback.message}` } },
-        ...(feedback.email ? [{ type: "section", fields: [{ type: "mrkdwn", text: `*이메일:*\n${feedback.email}` }] }] : []),
-        ...(feedback.metadata?.url ? [{ type: "context", elements: [{ type: "mrkdwn", text: `📍 ${feedback.metadata.url}` }] }] : []),
-      ],
-    };
-  }
-
-  if (webhookUrl.includes("discord.com/api/webhooks")) {
-    return {
-      embeds: [{
-        title: eventLabel,
-        color: feedback.type === "BUG" ? 0xef4444 : feedback.type === "FEATURE" ? 0x8b5cf6 : 0x3b82f6,
-        fields: [
-          { name: "유형", value: `${typeInfo.emoji} ${typeInfo.label}`, inline: true },
-          { name: "프로젝트", value: project.name, inline: true },
-          { name: "메시지", value: feedback.message },
-          ...(feedback.email ? [{ name: "이메일", value: feedback.email, inline: true }] : []),
-          ...(feedback.metadata?.url ? [{ name: "URL", value: feedback.metadata.url }] : []),
-        ],
-        timestamp: new Date().toISOString(),
-      }],
-    };
-  }
-
-  if (webhookUrl.includes("api.telegram.org")) {
-    const lines = [
-      `<b>${eventLabel}</b>`, ``,
-      `${typeInfo.emoji} <b>유형:</b> ${typeInfo.label}`,
-      `📁 <b>프로젝트:</b> ${project.name}`, ``,
-      `💬 <b>메시지:</b>`, feedback.message,
-    ];
-    if (feedback.email) lines.push(``, `📧 <b>이메일:</b> ${feedback.email}`);
-    if (feedback.metadata?.url) lines.push(``, `🔗 ${feedback.metadata.url}`);
-    return { text: lines.join("\n"), parse_mode: "HTML" };
-  }
-
-  return {
-    event: isTest ? "webhook.test" : "feedback.created",
-    timestamp: new Date().toISOString(),
-    feedback, project, organization,
-  };
-}
 
 export const testWebhookById = createServerFn({ method: "POST" })
   .inputValidator((d: { webhookId: string }) => d)


### PR DESCRIPTION
## Summary
- OCP 원칙에 따라 웹훅 포맷터를 Strategy 패턴으로 리팩토링
- organization.ts, webhook.ts 중복 코드 제거 (~175줄 → 공통 모듈)
- 새 서비스 추가 시 포맷터만 추가하면 됨 (기존 코드 수정 불필요)

Closes #40

## 구조
```
lib/webhook/
├── formatters/
│   ├── slack.ts      # Slack Block Kit
│   ├── discord.ts    # Discord Embed
│   ├── telegram.ts   # Telegram HTML
│   ├── generic.ts    # 기본 JSON
│   └── index.ts      # Factory (getFormatter)
├── types.ts          # 타입 정의
├── utils.ts          # 공통 유틸 (getTypeInfo, getEventLabel)
└── index.ts          # Public API (formatWebhookPayload)
```

## 확장성
```typescript
// 새 서비스 추가 예시 (Microsoft Teams)
// 1. formatters/teams.ts 생성
// 2. formatters/index.ts에 패턴 추가
const formatters = [
  { pattern: "hooks.slack.com", formatter: slackFormatter },
  { pattern: "webhook.office.com", formatter: teamsFormatter }, // 추가
  ...
];
```

## Test plan
- [x] 타입 체크 통과
- [x] 빌드 성공
- [ ] Slack/Discord/Telegram 웹훅 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)